### PR TITLE
Update Traefik job spec certificate resolver name

### DIFF
--- a/playbooks/templates/traefik.hcl.j2
+++ b/playbooks/templates/traefik.hcl.j2
@@ -125,7 +125,7 @@ entryPoint = "traefik"
 {% endif %}
 {% if job_fact.acme_challenge is defined %}
 {% if job_fact.acme_challenge == 'dns' and azure %}
-[certificatesResolvers.sejo.acme.dnsChallenge]
+[certificatesResolvers.{{ consul_dc_name }}.acme.dnsChallenge]
     provider = "azure"
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Updated traefik.toml in Traefik job spec to follow using templated consul datacenter name for the name of certificate resolver