### PR TITLE
Update Consul gRPC ports variable

### DIFF
--- a/playbooks/roles/consul/templates/consul.json.j2
+++ b/playbooks/roles/consul/templates/consul.json.j2
@@ -17,7 +17,7 @@
     "grpc": "{{ vm_ip }}"
   },
   "ports": {
-    "grpc": 8502
+    "grpc_tls": 8502
   },
   {% if 'admin' in group_names %}
   "server": true,


### PR DESCRIPTION
Consul wouldn't start. Logs reported that the `ports.grpc` value was invalid. After investigation it seems that when using TLS on gRPC traffic, you need to either use the default port bindings or specify `ports.grpc_tls` instead of the just `ports.grpc`. Changing this to `ports.grpc_tls` allowed consul to start.

Sources:
- [rpc-encryption-with-tls](https://developer.hashicorp.com/consul/docs/security/encryption#rpc-encryption-with-tls)
- [Consul docs on ports config](https://developer.hashicorp.com/consul/docs/agent/config/config-files#ports)
