### PR TITLE
Add health check to Nomad_job role

### DIFF
--- a/playbooks/roles/nomad-job/tasks/main.yml
+++ b/playbooks/roles/nomad-job/tasks/main.yml
@@ -71,6 +71,17 @@
   delay: 5
   until: nomad_job_spawn.failed == false
 
+- name: Check the job state is healthy
+  ansible.builtin.uri:
+    url: "http://nomad.service.consul:4646/v1/job/{{ job_name }}"
+    method: GET
+    # TODO Will be needed if ACL is ever set up 
+    # headers:
+    #   X-Nomad-Token: "{{ nomad_token }}"
+    remote_src: yes
+  register: job_status
+  until: job_status | json_query('json.Status') == 'running' 
+
 - name: debug
   debug:
     msg: "{{ nomad_job_spawn }}"

--- a/playbooks/roles/nomad-job/tasks/main.yml
+++ b/playbooks/roles/nomad-job/tasks/main.yml
@@ -75,12 +75,14 @@
   ansible.builtin.uri:
     url: "http://nomad.service.consul:4646/v1/job/{{ job_name }}"
     method: GET
-    # TODO Will be needed if ACL is ever set up 
-    # headers:
-    #   X-Nomad-Token: "{{ nomad_token }}"
     remote_src: yes
+  async: 600
+  poll: 5
   register: job_status
   until: job_status | json_query('json.Status') == 'running' 
+  retries: 5
+  delay: 3
+  
 
 - name: debug
   debug:


### PR DESCRIPTION
Added health check to Nomad_Job role using nomad api. Task loops until the status attribute of the response body is running. This is to prevent the playbook attempting to configure services which are not in a healthy state.