### PR TITLE
Implement Azure CSI disk creation and registration

### DIFF
--- a/playbooks/roles/nomad/tasks/csi_plugins.yml
+++ b/playbooks/roles/nomad/tasks/csi_plugins.yml
@@ -1,0 +1,25 @@
+
+ - name: Deploy CSI Controller plugin
+   community.general.nomad_job:
+     host: "nomad.service.consul"
+     state: present
+     content: "{{ lookup('ansible.builtin.template', item + '.hcl.j2') }}"
+     use_ssl: false
+   register: nomad_job_spawn
+   retries: 10
+   delay: 5
+   until: nomad_job_spawn.failed == false
+
+ - name: Check the job state is healthy
+   ansible.builtin.uri:
+     url: "http://nomad.service.consul:4646/v1/job/{{ job_name }}"
+     method: GET
+     # headers:
+     #   X-Nomad-Token: "{{ nomad_token }}"
+     remote_src: yes
+   register: job_status
+   until: job_status | json_query('json.Status') == 'running' 
+
+ - name: debug
+   debug:
+     msg: "{{ nomad_job_spawn }}"

--- a/playbooks/roles/nomad/tasks/csi_volumes.yml
+++ b/playbooks/roles/nomad/tasks/csi_volumes.yml
@@ -4,20 +4,9 @@
   ansible.builtin.uri:
     url: "http://nomad.service.consul:4646/v1/volume/csi/{{ item.id }}"
     method: GET
-    # headers:
-    #   X-Nomad-Token: "{{ nomad_token }}"
     remote_src: yes
   register: volume_exists
   ignore_errors: true
-
-- name: Check variables
-  ansible.builtin.debug:
-    msg: |
-      Name: {{ item.name }}
-      Id: {{ item.id }}
-      PluginID: {{ nomad_csi_plugin_id }}
-
-      
 
 - name: Check for state of CSI Plugins to prevent race
   block:
@@ -25,57 +14,21 @@
     ansible.builtin.uri:
       url: "http://nomad.service.consul:4646/v1/job/plugin-azure_csi_controller"
       method: GET
-      # headers:
-      #   X-Nomad-Token: "{{ nomad_token }}"
       remote_src: yes
     register: controller_status
     until: controller_status | json_query('json.Status') == 'running'
-
   - name: Check node plugin
     ansible.builtin.uri:
       url: "http://nomad.service.consul:4646/v1/job/plugin-azure_csi_node"
       method: GET
-      # headers:
-      #   X-Nomad-Token: "{{ nomad_token }}"
       remote_src: yes
     register: node_status
     until: node_status | json_query('json.Status') == 'running' 
-
-
-- name: Create CSI volume with Nomad API
-  ansible.builtin.uri:
-    url: http://nomad.service.consul:4646/v1/volume/csi/{{ item.id }}/create
-    method: PUT
-    # headers:
-    #   X-Nomad-Token: "{{ nomad_token }}"
-    # body: "{{ lookup('template', 'csi-volumes.json.j2') }}"
-    body_format: json
-    body: >
-      {
-        "Volumes": [
-          {
-            "ID": "{{ item.id }}",
-            "Name": "{{ item.name }}",
-            "Namespace": "default",
-            "PluginID": "{{ nomad_csi_plugin_id }}",
-            "MountOptions": {
-              "FsType": "ext4",
-              "MountFlags": ["ro", "noatime"],
-            },
-            "RequestedCapacityMin": 53687091200,
-            "RequestedCapacityMax": 53687091200,
-            "RequestedCapabilities": [
-              {
-                "AccessMode": "single-node-writer",
-                "AttachmentMode": "file-system"
-              },
-              {
-                "AccessMode": "single-node-writer",
-                "AttachmentMode": "block-device"
-              }
-            ],
-          }
-        ]
-      }
-    remote_src: yes
+  - name: Create CSI volume with Nomad API
+    ansible.builtin.uri:
+      url: http://nomad.service.consul:4646/v1/volume/csi/{{ item.id }}/create
+      method: PUT
+      body_format: json
+      body: "{{ lookup('template', 'csi-volumes.json.j2') }}" 
+      remote_src: yes
   when: volume_exists.status == 404

--- a/playbooks/roles/nomad/tasks/csi_volumes.yml
+++ b/playbooks/roles/nomad/tasks/csi_volumes.yml
@@ -1,0 +1,81 @@
+---
+
+- name: Check if volume has already been created and registered
+  ansible.builtin.uri:
+    url: "http://nomad.service.consul:4646/v1/volume/csi/{{ item.id }}"
+    method: GET
+    # headers:
+    #   X-Nomad-Token: "{{ nomad_token }}"
+    remote_src: yes
+  register: volume_exists
+  ignore_errors: true
+
+- name: Check variables
+  ansible.builtin.debug:
+    msg: |
+      Name: {{ item.name }}
+      Id: {{ item.id }}
+      PluginID: {{ nomad_csi_plugin_id }}
+
+      
+
+- name: Check for state of CSI Plugins to prevent race
+  block:
+  - name: Check controller plugin 
+    ansible.builtin.uri:
+      url: "http://nomad.service.consul:4646/v1/job/plugin-azure_csi_controller"
+      method: GET
+      # headers:
+      #   X-Nomad-Token: "{{ nomad_token }}"
+      remote_src: yes
+    register: controller_status
+    until: controller_status | json_query('json.Status') == 'running'
+
+  - name: Check node plugin
+    ansible.builtin.uri:
+      url: "http://nomad.service.consul:4646/v1/job/plugin-azure_csi_node"
+      method: GET
+      # headers:
+      #   X-Nomad-Token: "{{ nomad_token }}"
+      remote_src: yes
+    register: node_status
+    until: node_status | json_query('json.Status') == 'running' 
+
+
+- name: Create CSI volume with Nomad API
+  ansible.builtin.uri:
+    url: http://nomad.service.consul:4646/v1/volume/csi/{{ item.id }}/create
+    method: PUT
+    # headers:
+    #   X-Nomad-Token: "{{ nomad_token }}"
+    # body: "{{ lookup('template', 'csi-volumes.json.j2') }}"
+    body_format: json
+    body: >
+      {
+        "Volumes": [
+          {
+            "ID": "{{ item.id }}",
+            "Name": "{{ item.name }}",
+            "Namespace": "default",
+            "PluginID": "{{ nomad_csi_plugin_id }}",
+            "MountOptions": {
+              "FsType": "ext4",
+              "MountFlags": ["ro", "noatime"],
+            },
+            "RequestedCapacityMin": 53687091200,
+            "RequestedCapacityMax": 53687091200,
+            "RequestedCapabilities": [
+              {
+                "AccessMode": "single-node-writer",
+                "AttachmentMode": "file-system"
+              },
+              {
+                "AccessMode": "single-node-writer",
+                "AttachmentMode": "block-device"
+              }
+            ],
+          }
+        ]
+      }
+    remote_src: yes
+  when: volume_exists.status == 404

--- a/playbooks/roles/nomad/templates/azure_csi_controller.hcl.j2
+++ b/playbooks/roles/nomad/templates/azure_csi_controller.hcl.j2
@@ -1,0 +1,67 @@
+job "{{ nomad_csi_plugin_job_name }}" {
+  datacenters = ["{{ nomad_datacenter }}"]
+  type = "service"
+
+  group "controller" {
+    count = 2
+
+    constraint { 
+      distinct_hosts = true
+    }
+
+    # disable deployments
+    update {
+      max_parallel = 0
+    }
+    task "controller" {
+      driver = "docker"
+
+      template {
+        change_mode = "noop"
+        destination = "local/azure.json"
+        data = <<EOH
+{
+"cloud":"AzurePublicCloud",
+"tenantId": "{{ tenant_id }}",
+"subscriptionId": "{{ subscription_id }}",
+"aadClientId": "{{ client_id }}",
+"aadClientSecret": "{{ client_secret }}",
+"resourceGroup": "{{ rg }}",
+"location": "westeurope"
+}
+EOH
+      }
+
+      env {
+        AZURE_CREDENTIAL_FILE = "/etc/kubernetes/azure.json"
+      }
+
+      config {
+        image = "{{ nomad_csi_plugin_image }}"
+
+        volumes = [
+          "local/azure.json:/etc/kubernetes/azure.json"
+        ]
+
+        args = [
+          "--endpoint=unix://csi/csi.sock",
+          "--logtostderr",
+          "--v=5",
+        ]
+      }
+
+      csi_plugin {
+        id        = "{{ nomad_csi_plugin_id }}"
+        type      = "controller"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        memory = 256
+      }
+      # Give the plugin enough time to shutdown gracefully
+      kill_timeout = "2m"
+    }
+  }
+}
+

--- a/playbooks/roles/nomad/templates/azure_csi_controller.hcl.j2
+++ b/playbooks/roles/nomad/templates/azure_csi_controller.hcl.j2
@@ -27,7 +27,7 @@ job "{{ nomad_csi_plugin_job_name }}" {
 "aadClientId": "{{ client_id }}",
 "aadClientSecret": "{{ client_secret }}",
 "resourceGroup": "{{ rg }}",
-"location": "westeurope"
+"location": "{{ azure_region }}"
 }
 EOH
       }
@@ -38,7 +38,7 @@ EOH
 
       config {
         image = "{{ nomad_csi_plugin_image }}"
-
+        network_mode = "host"
         volumes = [
           "local/azure.json:/etc/kubernetes/azure.json"
         ]

--- a/playbooks/roles/nomad/templates/azure_csi_node.hcl.j2
+++ b/playbooks/roles/nomad/templates/azure_csi_node.hcl.j2
@@ -1,0 +1,58 @@
+job "{{ nomad_csi_plugin_job_name }}" {
+  datacenters = ["{{ nomad_datacenter }}"]
+  type = "system"
+
+  group "nodes" {
+    task "node" {
+      driver = "docker"
+
+      template {
+        change_mode = "noop"
+        destination = "local/azure.json"
+        data = <<EOH
+{
+"cloud":"AzurePublicCloud",
+"tenantId": "{{ tenant_id }}",
+"subscriptionId": "{{ subscription_id }}",
+"aadClientId": "{{ client_id }}",
+"aadClientSecret": "{{ client_secret }}",
+"resourceGroup": "{{ rg }}",
+"location": "westeurope"
+}
+EOH
+      }
+
+      env {
+        AZURE_CREDENTIAL_FILE = "/etc/kubernetes/azure.json"
+      }
+
+      config {
+        image = "{{ nomad_csi_plugin_image }}"
+        volumes = [
+          "local/azure.json:/etc/kubernetes/azure.json"
+        ]
+        args = [
+          "--nodeid={{ nomad_csi_plugin_node_id }}",
+          "--endpoint=unix://csi/csi.sock",
+          "--logtostderr",
+          "--v=5",
+        ]
+        privileged = true
+      }
+
+      csi_plugin {
+        id        = "{{ nomad_csi_plugin_id }}"
+        type      = "node"
+        mount_dir = "/csi"
+      }
+
+      resources {
+        memory = 256
+      }
+
+      # ensuring the plugin has time to shut down gracefully
+      kill_timeout = "2m"
+    }
+  }
+}
+

--- a/playbooks/roles/nomad/templates/azure_csi_node.hcl.j2
+++ b/playbooks/roles/nomad/templates/azure_csi_node.hcl.j2
@@ -17,7 +17,7 @@ job "{{ nomad_csi_plugin_job_name }}" {
 "aadClientId": "{{ client_id }}",
 "aadClientSecret": "{{ client_secret }}",
 "resourceGroup": "{{ rg }}",
-"location": "westeurope"
+"location": "{{ azure_region }}"
 }
 EOH
       }
@@ -28,6 +28,7 @@ EOH
 
       config {
         image = "{{ nomad_csi_plugin_image }}"
+        network_mode = "host"
         volumes = [
           "local/azure.json:/etc/kubernetes/azure.json"
         ]

--- a/playbooks/roles/nomad/templates/csi-volumes.json.j2
+++ b/playbooks/roles/nomad/templates/csi-volumes.json.j2
@@ -1,0 +1,27 @@
+{
+  "Volumes": [
+    {
+      "ID": "{{ item.id }}",
+      "Name": "{{ item.name }}",
+      "Namespace": "default",
+      "PluginID": "{{ nomad_csi_plugin_id }}",
+      "MountOptions": {
+        "FsType": "ext4",
+        "MountFlags": ["ro", "noatime"]
+      },
+      "RequestedCapacityMin": 53687091200,
+      "RequestedCapacityMax": 53687091200,
+      "RequestedCapabilities": [
+        {
+          "AccessMode": "single-node-writer",
+          "AttachmentMode": "file-system"
+        },
+        {
+          "AccessMode": "single-node-writer",
+          "AttachmentMode": "block-device"
+        }
+      ]
+    }
+  ]
+}
+

--- a/playbooks/roles/nomad/templates/csi-volumes.json.j2
+++ b/playbooks/roles/nomad/templates/csi-volumes.json.j2
@@ -3,14 +3,14 @@
     {
       "ID": "{{ item.id }}",
       "Name": "{{ item.name }}",
-      "Namespace": "default",
+      "Namespace": "{{ item.namespace }}",
       "PluginID": "{{ nomad_csi_plugin_id }}",
       "MountOptions": {
-        "FsType": "ext4",
-        "MountFlags": ["ro", "noatime"]
+        "FsType": "{{ item.filesystem }}",
+        "MountFlags": ["noatime"]
       },
-      "RequestedCapacityMin": 53687091200,
-      "RequestedCapacityMax": 53687091200,
+      "RequestedCapacityMin": {{ item.size }},
+      "RequestedCapacityMax": {{ item.size }},
       "RequestedCapabilities": [
         {
           "AccessMode": "single-node-writer",


### PR DESCRIPTION
## Problem: 
Stateful services need some persistent storage to allow to resilient across restarts and/or workload reallocations regardless of which client node Nomad schedules them to. 
## Solution: 
Use the [Azure Disks CSI plugin](https://github.com/kubernetes-sigs/azuredisk-csi-driver). 
## Implementation: 
Two tasks have been added to the Nomad role. The first deploys the CSI plugins (controller and node) to the Nomad cluster. The second posts a volume specification to the local nomad api on one of the server nodes. This instructs the controller plugin to request the creation of Azure disk resource (using the credentials and resource group provided to CSI plugin job spec). This volume is then registered in Nomad to allow it to be used by future jobs.