### PR TITLE
Disable the acme dns txt record propagation checks

### DIFF
--- a/playbooks/templates/traefik.hcl.j2
+++ b/playbooks/templates/traefik.hcl.j2
@@ -127,6 +127,7 @@ entryPoint = "traefik"
 {% if job_fact.acme_challenge == 'dns' and azure %}
 [certificatesResolvers.{{ consul_dc_name }}.acme.dnsChallenge]
     provider = "azure"
+    disablePropagationCheck = true
 {% endif %}
 {% endif %}
 EOF


### PR DESCRIPTION
### Context
By default Traefik verifies the existence of the txt records it creates before asking acme to verify.
### Problem
This seems to have been causing a situation where Traefik would never be able to verify itself that the txt records were successfully and would therefore never notify acme that it would like to complete the DNS-01 challenge. In this situation Traefik would never successfully request certificates from Lets Encrypt.
### Solution
Since we know that Traefik is successfully creating the txt records, this pull requests adds configuration to disable the propagation checks which allows traefik to request a certificate from LE.    